### PR TITLE
C++: use vStringCopyS to create an anonymous identifier

### DIFF
--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -130,7 +130,7 @@ CXXToken * cxxTokenCreateAnonymousIdentifier(void)
 
 
 	t->eType = CXXTokenTypeIdentifier;
-	t->pszWord = vStringNewInit("__anon");
+	vStringCopyS(t->pszWord, "__anon");
 
 	// The names of anonymous structures depend on the name of the file being processed
 	// so the identifiers won't collide across multiple ctags runs with different file sets.


### PR DESCRIPTION
t->pszWord points existing vString object.
Assigning a new object causes memory leaking.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>