### PR TITLE
C++: add local Makefile to kick the top level Makefile

### DIFF
--- a/parsers/cxx/Makefile
+++ b/parsers/cxx/Makefile
@@ -1,0 +1,8 @@
+all:
+.SUFFIXES:
+.SUFFIXES: .c .o
+
+.c.o:
+	$(MAKE) -C ../.. parsers/cxx/$@
+%:
+	$(MAKE) -C ../.. $@


### PR DESCRIPTION
This is helpful to run make from cxx parser own directory.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>