### PR TITLE
OldC, OldC++: provide the way to enable temporarily old parser usable

### DIFF
--- a/main/parsers.h
+++ b/main/parsers.h
@@ -59,6 +59,8 @@
 	MakefileParser, \
 	MatLabParser, \
 	ObjcParser, \
+	OldCppParser, \
+	OldCParser, \
 	OcamlParser, \
 	PascalParser, \
 	PerlParser, \

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3549,12 +3549,13 @@ static void initializeVeraParser (const langType language)
 extern parserDefinition* OldCParser (void)
 {
 	static const char *const extensions [] = { "c", NULL };
-	parserDefinition* def = parserNew ("C");
+	parserDefinition* def = parserNew ("OldC");
 	def->kinds      = CKinds;
 	def->kindCount  = ARRAY_SIZE (CKinds);
 	def->extensions = extensions;
 	def->parser2    = findCTags;
 	def->initialize = initializeCParser;
+	def->enabled = 0;
 	return def;
 }
 
@@ -3583,13 +3584,14 @@ extern parserDefinition* OldCppParser (void)
 	static selectLanguage selectors[] = { selectByObjectiveCKeywords,
 					      NULL };
 
-	parserDefinition* def = parserNew ("C++");
+	parserDefinition* def = parserNew ("OldC++");
 	def->kinds      = CKinds;
 	def->kindCount  = ARRAY_SIZE (CKinds);
 	def->extensions = extensions;
 	def->parser2    = findCTags;
 	def->initialize = initializeCppParser;
 	def->selectLanguage = selectors;
+	def->enabled = 0;
 	return def;
 }
 


### PR DESCRIPTION
This is helpful for comparing the output of the new parsers and old parsers.

This is a speculative commit.
After merging commits proposed in #837, you can old parser
with following command line:

   $ ./ctags --verbose  -o - --c-kinds=+p --languages=-C --languages=+OldC --print-language \
             ~/var/ctags-github/Units/parser-c.r/bug1458930.c.d/input.c

This change should be removed in the future.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>