### PR TITLE
Units,C++: add an input crashing ctags

### DIFF
--- a/Units/parser-cxx.r/broken-input.d/input.cc
+++ b/Units/parser-cxx.r/broken-input.d/input.cc
@@ -1,0 +1,4 @@
+__attribute__((visibility("protected")))
+        f1(int f1p1,int f1p2 __attribute__([(unused)),int f1p3)
+                __attribute__ ((warn_unused_result,always_inline,deprecated))
+{


### PR DESCRIPTION
Fixed in the last commit.
This one is found by "make noise" test harness.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>