### PR TITLE
Units,C: add an input crashing ctags

### DIFF
--- a/Units/parser-c.r/broken-input-cxx-operator.d/input.c
+++ b/Units/parser-c.r/broken-input-cxx-operator.d/input.c
@@ -1,0 +1,1 @@
+struct a::b{


### PR DESCRIPTION
As reported in #1664.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>